### PR TITLE
Provide UTF-8 Letter To Sound rules support

### DIFF
--- a/include/cst_lts.h
+++ b/include/cst_lts.h
@@ -40,34 +40,47 @@
 #ifndef _CST_LTS_H__
 #define _CST_LTS_H__
 
-#include <stdint.h>
-#include "cst_val.h"
 #include "cst_string.h"
+#include "cst_val.h"
+#include <stdint.h>
 
 typedef uint16_t cst_lts_addr;
-typedef unsigned char cst_lts_feat;
+/* The feat typically holds which context character is the rule considering or
+ * CST_LTS_EOR if it is a terminal rule. As there are typically <=8 features, we
+ * can use a uint8_t type, that can hold up to 255 features (+ terminal rule) */
+typedef uint8_t cst_lts_feat;
+/* cst_lts_phone and cst_lts_letter must be of the same type to save space.
+ * They hold a unicode code point and therefore require 21 bits.
+ */
 typedef uint32_t cst_lts_letter;
-typedef cst_lts_letter cst_lts_phone; /* cst_lts_phone and cst_lts_letter must be of the same type */
+typedef cst_lts_letter cst_lts_phone;
+/* The feat_val type can hold both the cst_lts_feat and the cst_lts_letter type.
+ * Because cst_lts_letter requires 21 bits and cst_lts_feat requires 8 bits,
+ * there is a possible bit encoding to put both of them on a single uint32_t,
+ * saving space.*/
+typedef uint32_t cst_lts_feat_val;
+
+typedef struct cst_lts_rule_struct {
+    cst_lts_feat_val feat_val;
+    cst_lts_addr qtrue;
+    cst_lts_addr qfalse;
+} cst_lts_rule;
 
 /* end of rule value: If this feature is found, we are on a terminal node */
 #define CST_LTS_EOR 255
 
 typedef struct cst_lts_rules_struct {
     char *name;
-    const cst_lts_addr *letter_index;   /* index into model first state */
-    cst_lts_feat *feats;
-    cst_lts_letter *vals;
-    cst_lts_addr *qtrues;
-    cst_lts_addr *qfalses;
+    cst_lts_rule *model;
     const char *const *phone_table;
     int context_window_size;
-    int context_extra_feats; /* Size of the extra features, measured in cst_lts_letter */
-    map_unicode_to_int *letter_table;
+    int context_extra_feats; /* Size of the extra features, measured in
+                                cst_lts_letter */
+    map_unicode_to_int *letter_index;
 } cst_lts_rules;
 
 cst_lts_rules *new_lts_rules();
 
-cst_val *lts_apply(const char *word, const char *feats,
-                   const cst_lts_rules *r);
+cst_val *lts_apply(const char *word, const char *feats, const cst_lts_rules *r);
 
 #endif

--- a/include/cst_lts.h
+++ b/include/cst_lts.h
@@ -40,40 +40,34 @@
 #ifndef _CST_LTS_H__
 #define _CST_LTS_H__
 
+#include <stdint.h>
 #include "cst_val.h"
+#include "cst_string.h"
 
-typedef unsigned short cst_lts_addr;
-typedef int cst_lts_phone;
+typedef uint16_t cst_lts_addr;
 typedef unsigned char cst_lts_feat;
-typedef unsigned char cst_lts_letter;
-typedef unsigned char cst_lts_model;
+typedef uint32_t cst_lts_letter;
+typedef cst_lts_letter cst_lts_phone; /* cst_lts_phone and cst_lts_letter must be of the same type */
 
-/* end of rule value */
+/* end of rule value: If this feature is found, we are on a terminal node */
 #define CST_LTS_EOR 255
 
 typedef struct cst_lts_rules_struct {
     char *name;
     const cst_lts_addr *letter_index;   /* index into model first state */
-    const cst_lts_model *models;
+    cst_lts_feat *feats;
+    cst_lts_letter *vals;
+    cst_lts_addr *qtrues;
+    cst_lts_addr *qfalses;
     const char *const *phone_table;
     int context_window_size;
-    int context_extra_feats;
-    const char *const *letter_table;
+    int context_extra_feats; /* Size of the extra features, measured in cst_lts_letter */
+    map_unicode_to_int *letter_table;
 } cst_lts_rules;
-
-/* Note this is designed to be 6 bytes */
-typedef struct cst_lts_rule_struct {
-    cst_lts_feat feat;
-    cst_lts_letter val;
-    cst_lts_addr qtrue;
-    cst_lts_addr qfalse;
-} cst_lts_rule;
 
 cst_lts_rules *new_lts_rules();
 
 cst_val *lts_apply(const char *word, const char *feats,
                    const cst_lts_rules *r);
-cst_val *lts_apply_val(const cst_val *wlist, const char *feats,
-                       const cst_lts_rules *r);
 
 #endif

--- a/include/cst_string.h
+++ b/include/cst_string.h
@@ -41,6 +41,7 @@
 #define __CST_STRING_H__
 
 #include <string.h>
+#include <stdint.h>
 
 /* typedef unsigned char cst_string; */
 typedef char cst_string;
@@ -62,5 +63,10 @@ char *cst_strcat3(const char *a, const char *b, const char *c);
 
 cst_string *cst_downcase(const cst_string *str);
 cst_string *cst_upcase(const cst_string *str);
+
+uint32_t utf8char_to_cp(const cst_string *const utf8char);
+void cp_to_utf8char(const uint32_t cp, unsigned char *utf8char);
+
+
 
 #endif

--- a/include/cst_string.h
+++ b/include/cst_string.h
@@ -67,6 +67,23 @@ cst_string *cst_upcase(const cst_string *str);
 uint32_t utf8char_to_cp(const cst_string *const utf8char);
 void cp_to_utf8char(const uint32_t cp, unsigned char *utf8char);
 
+/* With this struct you can map unicode code points to int32_t in a reasonable way.
+   With ASCII you can simply create "int32_t vector[256];" and that is it, with
+   Unicode code points the full space would be 2^21, but we don't want to use all
+   that memory.
+*/
+typedef struct struct_map_unicode_to_int {
+    int32_t *v1;
+    int32_t **v2;
+    int32_t ***v3;
+    int32_t ****v4;
+    int32_t not_found; /* not found return value */
+    int freeable;
+} map_unicode_to_int;
+
+map_unicode_to_int* cst_unicode_int_map_create();
+void cst_unicode_int_map_delete(map_unicode_to_int *m);
+int32_t cst_unicode_int_map(map_unicode_to_int *m, const unsigned char *utf8char, int set, int32_t value);
 
 
 #endif

--- a/main/t2p_main.c
+++ b/main/t2p_main.c
@@ -69,7 +69,6 @@ static cst_voice *voice_no_wave(const char *lang_code, const char *dialect,
 {
     const cst_lang *lang = mimic_get_lang(lang_code);
     cst_voice *v = new_voice();
-    cst_lexicon *lex;
 
     v->name = "no_wave_voice";
 
@@ -93,6 +92,7 @@ static cst_voice *voice_no_wave(const char *lang_code, const char *dialect,
     /* Lexicon */
     if (lang->lex_init != NULL)
     {
+        cst_lexicon *lex;
         lex = lang->lex_init();
         feat_set(v->features, "lexicon", lexicon_val(lex));
         if (lex->postlex != NULL)
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     cst_voice *v;
     cst_utterance *u;
     cst_item *s;
-    const char *text, *lang, *dialect, *name;
+    const char *text, *lang, *dialect;
     int use_addenda = 1;
     int use_lexicon = 1;
 
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
 
     for (s = relation_head(utt_relation(u, "Segment")); s; s = item_next(s))
     {
-        name = item_feat_string(s, "name");
+        const char *name = item_feat_string(s, "name");
         printf("%s", name);
         /* If its a vowel and is stessed output stress value */
         if ((cst_streq("+", ffeature_string(s, "ph_vc"))) &&

--- a/main/t2p_main.c
+++ b/main/t2p_main.c
@@ -1,0 +1,169 @@
+/*************************************************************************/
+/*                                                                       */
+/*                  Language Technologies Institute                      */
+/*                     Carnegie Mellon University                        */
+/*                         Copyright (c) 2001                            */
+/*                        All Rights Reserved.                           */
+/*                                                                       */
+/*  Permission is hereby granted, free of charge, to use and distribute  */
+/*  this software and its documentation without restriction, including   */
+/*  without limitation the rights to use, copy, modify, merge, publish,  */
+/*  distribute, sublicense, and/or sell copies of this work, and to      */
+/*  permit persons to whom this work is furnished to do so, subject to   */
+/*  the following conditions:                                            */
+/*   1. The code must retain the above copyright notice, this list of    */
+/*      conditions and the following disclaimer.                         */
+/*   2. Any modifications must be clearly marked as such.                */
+/*   3. Original authors' names are not deleted.                         */
+/*   4. The authors' names are not used to endorse or promote products   */
+/*      derived from this software without specific prior written        */
+/*      permission.                                                      */
+/*                                                                       */
+/*  CARNEGIE MELLON UNIVERSITY AND THE CONTRIBUTORS TO THIS WORK         */
+/*  DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING      */
+/*  ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT   */
+/*  SHALL CARNEGIE MELLON UNIVERSITY NOR THE CONTRIBUTORS BE LIABLE      */
+/*  FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES    */
+/*  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN   */
+/*  AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,          */
+/*  ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF       */
+/*  THIS SOFTWARE.                                                       */
+/*                                                                       */
+/*************************************************************************/
+/*             Author:  Alan W Black (awb@cs.cmu.edu)                    */
+/*               Date:  January 2001                                     */
+/*************************************************************************/
+/*                                                                       */
+/*  For text to phones                                                   */
+/*                                                                       */
+/*************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+
+#include "cst_args.h"
+#include "cst_error.h"
+#include "mimic.h"
+
+static cst_utterance *no_wave_synth(cst_utterance *u)
+{
+    return u;
+}
+
+const cst_lang* mimic_get_lang(const char *lang)
+{
+    size_t i;
+    /* Search mimic_lang_list for lang_init() and lex_init(); */
+    for (i = 0; mimic_lang_list[i].lang; ++i)
+    {
+        if (cst_streq(lang, mimic_lang_list[i].lang))
+        {
+            return &mimic_lang_list[i];
+        }
+    }
+    return NULL;
+}
+
+static cst_voice *voice_no_wave(const char *lang_code, const char *dialect)
+{
+    const cst_lang *lang = mimic_get_lang(lang_code);
+    cst_voice *v = new_voice();
+    cst_lexicon *lex;
+
+    v->name = "no_wave_voice";
+
+    /* Set up basic values for synthesizing with this voice */
+    if (lang == NULL)
+    {
+       cst_errmsg("Language %s not found\n", lang_code);
+       return NULL;
+    }
+
+    if (lang->lang_init != NULL)
+    {
+        lang->lang_init(v);
+    }
+    mimic_feat_set_string(v->features, "name", "voice_no_wave");
+    if (dialect != NULL)
+    {
+        mimic_feat_set_string(v->features, "dialect", dialect);
+    }
+
+    /* Lexicon */
+    if (lang->lex_init != NULL)
+    {
+        lex = lang->lex_init();
+        feat_set(v->features, "lexicon", lexicon_val(lex));
+        if (lex->postlex != NULL)
+        {
+            feat_set(v->features, "postlex_func", uttfunc_val(lex->postlex));
+        }
+    }
+
+    /* Intonation */
+    mimic_feat_set_string(v->features, "no_f0_target_model", "1");
+    mimic_feat_set_string(v->features, "no_segment_duration_model", "1");
+
+    /* Waveform synthesis: diphone_synth */
+    feat_set(v->features, "wave_synth_func", uttfunc_val(&no_wave_synth));
+
+    return v;
+}
+
+int main(int argc, char **argv)
+{
+    cst_val *files;
+    cst_features *args = new_features();
+    cst_voice *v;
+    cst_utterance *u;
+    cst_item *s;
+    const char *text, *lang, *dialect, *name;
+
+    files =
+        cst_args(argv, argc,
+                 "usage: t2p [OPTIONS]\n"
+                 "-lang <string> Language code to transcribe\n"
+                 "-dialect <string>  Dialect\n"
+                 "-t <string>  Text\n"
+                 "usage: t2p -lang en -t \"word word word\"\n"
+                 "Convert text to phonemes.", args);
+
+    text = get_param_string(args, "-t", NULL);
+    if (text == NULL)
+    {
+        fprintf(stderr, "no text specified\n");
+        exit(-1);
+    }
+    lang = get_param_string(args, "-lang", "en");
+    dialect = get_param_string(args, "-dialect", NULL);
+
+    mimic_core_init();
+    v = voice_no_wave(lang, dialect);
+    if (v == NULL)
+    {
+       cst_errmsg("Could not load voice with language '%s' and dialect '%s'\n", lang, dialect == NULL ? "" : dialect);
+       exit(-1);
+    }
+
+    u = mimic_synth_text(text, v);
+
+    for (s = relation_head(utt_relation(u, "Segment")); s; s = item_next(s))
+    {
+        name = item_feat_string(s, "name");
+        printf("%s", name);
+        /* If its a vowel and is stessed output stress value */
+        if ((cst_streq("+", ffeature_string(s, "ph_vc"))) &&
+            (cst_streq("1", ffeature_string(s, "R:SylStructure.parent.stress"))))
+            printf("1");
+        printf(" ");
+    }
+
+    printf("\n");
+
+    delete_utterance(u);
+    delete_features(args);
+    delete_val(files);
+
+    mimic_core_exit();
+    return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -420,6 +420,10 @@ mimicvox_info = executable('mimicvox_info', 'main/mimicvox_info_main.c',
                            dependencies: ttsmimic_core_dep,
                            install: true)
 
+t2pbin = executable('t2p', 'main/t2p_main.c', 
+                      dependencies: ttsmimic_core_dep,
+                      install: true)
+
 compile_regexes = executable('compile_regexes', 'main/compile_regexes.c',
                            dependencies: ttsmimic_core_dep,
                            install: true)

--- a/meson.build
+++ b/meson.build
@@ -200,7 +200,8 @@ conf_data.set('MIMIC_PACKAGE_VERSION', '"' + meson.project_version() + '"')
 conf_data.set('MIMIC_PACKAGE_URL', '"https://github.com/MycroftAI/mimic-core/issues"')
 
 mimic_config_h = configure_file(output : 'mimic_core_config.h',
-                                configuration : conf_data)
+                                configuration : conf_data,
+                                install_dir:  join_paths(get_option('includedir'), 'ttsmimic'))
 
 includes += include_directories('.')
 

--- a/src/lexicon/cst_lexicon.c
+++ b/src/lexicon/cst_lexicon.c
@@ -261,17 +261,27 @@ cst_val *lex_lookup(const cst_lexicon *l, const char *word, const char *pos,
     char *wp;
     cst_val *phones = 0;
     int found = FALSE;
+    const int use_addenda = get_param_int(feats, "use_addenda", 1);
+    const int use_lexicon = get_param_int(feats, "use_lexicon", 1);
 
     wp = cst_alloc(char, cst_strlen(word) + 2);
     cst_sprintf(wp, "%c%s", (pos ? pos[0] : '0'), word);
 
-    if (l->addenda)
+    if (l->addenda && use_addenda)
+    {
         phones = lex_lookup_addenda(wp, l, &found);
+    }
 
     if (!found)
     {
-        index = lex_lookup_bsearch(l, wp);
-
+        if (use_lexicon)
+        {
+            index = lex_lookup_bsearch(l, wp);
+        }
+        else
+        {
+            index = -1;
+        }
         if (index >= 0)
         {
             if (l->phone_hufftable)

--- a/src/lexicon/cst_lts.c
+++ b/src/lexicon/cst_lts.c
@@ -59,7 +59,7 @@ cst_lts_rules *new_lts_rules()
 
 cst_val *lts_apply(const char *word, const char *feats, const cst_lts_rules *r)
 {
-    int pos, index;
+    int pos;
     size_t i, i2, i3, num_cp_in_word;
     const cst_val *v;
     cst_val *phones = NULL;
@@ -110,6 +110,7 @@ cst_val *lts_apply(const char *word, const char *feats, const cst_lts_rules *r)
     for (pos = r->context_window_size + num_cp_in_word - 1;
          full_buff[pos] != word_limit; pos--)
     {
+        int index;
         /* Fill the features buffer for the predictor */
         /* This is the context before the letter: */
         for (i = 0; i < r->context_window_size; ++i)

--- a/src/synth/cst_synth.c
+++ b/src/synth/cst_synth.c
@@ -598,6 +598,10 @@ cst_utterance *flat_prosody(cst_utterance *u)
     cst_relation *targ_rel;
     float mean, stddev;
 
+
+    if (feat_present(u->features,"no_f0_target_model"))
+        return u;
+
     targ_rel = utt_relation_create(u, "Target");
     mean = get_param_float(u->features, "target_f0_mean", 100.0);
     mean *= get_param_float(u->features, "f0_shift", 1.0);

--- a/src/synth/cst_synth.c
+++ b/src/synth/cst_synth.c
@@ -483,9 +483,10 @@ cst_utterance *default_lexical_insertion(cst_utterance *u)
     cst_item *ssword, *sssyl, *segitem, *sylitem, *seg_in_syl;
     const cst_val *vpn;
     int dp = 0;
+    const int use_addenda = get_param_int(u->features, "use_addenda", 1);
 
     lex = val_lexicon(feat_val(u->features, "lexicon"));
-    if (lex->lex_addenda)
+    if (lex->lex_addenda && use_addenda)
         lex_addenda = lex->lex_addenda;
 
     syl = utt_relation_create(u, "Syllable");

--- a/src/synth/mimic.c
+++ b/src/synth/mimic.c
@@ -59,7 +59,7 @@
 /* mimic_main() */
 cst_val *mimic_voice_list = 0;
 cst_lang mimic_lang_list[20];
-int mimic_lang_list_length = 0;
+static int mimic_lang_list_length = 0;
 
 int mimic_core_init()
 {

--- a/src/utils/cst_string.c
+++ b/src/utils/cst_string.c
@@ -260,14 +260,13 @@ void cst_unicode_int_map_delete(map_unicode_to_int *m)
   {
     return;
   }
-  int i, j, k;
   if(m->v1 != NULL)
   {
     cst_free(m->v1);
   }
   if (m->v2 != NULL)
   {
-    for (i = 0; i < 32; i++)
+    for (int i = 0; i < 32; i++)
     {
         if (m->v2[i] != NULL)
         {
@@ -278,11 +277,11 @@ void cst_unicode_int_map_delete(map_unicode_to_int *m)
   }
   if (m->v3 != NULL)
   {
-    for (i = 0; i < 16; i++)
+    for (int i = 0; i < 16; i++)
     {
       if (m->v3[i] != NULL)
       {
-        for (j = 0; j < 64; j++)
+        for (int j = 0; j < 64; j++)
         {
            if (m->v3[i][j] != NULL)
            {
@@ -296,15 +295,15 @@ void cst_unicode_int_map_delete(map_unicode_to_int *m)
   }
   if (m->v4 != NULL)
   {
-    for (i = 0; i < 8; i++)
+    for (int i = 0; i < 8; i++)
     {
       if (m->v4[i] != NULL)
       {
-        for (j = 0; j < 64; j++)
+        for (int j = 0; j < 64; j++)
         {
           if (m->v4[i][j] != NULL)
           {
-            for (k = 0; k < 64; k++)
+            for (int k = 0; k < 64; k++)
             {
               if (m->v4[i][j][k] != NULL)
               {

--- a/src/utils/cst_tokenstream.c
+++ b/src/utils/cst_tokenstream.c
@@ -52,53 +52,6 @@ const cst_string *const cst_ts_default_postpunctuationsymbols =
 static void ts_getc(cst_tokenstream *ts);
 static void internal_ts_getc(cst_tokenstream *ts);
 
-static uint32_t utf8char_to_cp(const cst_string *const utf8char)
-{
-    unsigned char c1, c2, c3, c4;
-    unsigned char *c = (unsigned char *) utf8char;
-    uint32_t cp;
-    switch (cst_strlen(c))
-    {
-    case 1:
-        /* 1st byte must be 0xxxxxxx so we mask with b01111111 = 0x7f */
-        cp = c[0] & 0x7f;
-        return cp;
-    case 2:
-        /* 1st byte must be 110xxxxx so we mask with b00011111 = 0x1f */
-        c1 = c[0] & 0x1f;
-        /* 2nd byte must be 10xxxxxx so we mask with b00111111 = 0x3f */
-        c2 = c[1] & 0x3f;
-        /* We shift the bits of c1 6 positions to the left, and fill
-     * those 6 positions with c2 */
-        cp = (c1 << 6) | c2;
-        return cp;
-    case 3:
-        /* 1st byte must be 1110xxxx so we mask with b00011111 = 0x0f */
-        c1 = c[0] & 0x0f;
-        /* 2nd byte must be 10xxxxxx so we mask with b00111111 = 0x3f */
-        c2 = c[1] & 0x3f;
-        /* 3rd byte must be 10xxxxxx so we mask with b00111111 = 0x3f */
-        c3 = c[2] & 0x3f;
-        /* We shift the bits of c1 12 positions to the left, and fill
-     * the 12 positions with 6 bits from c2 and 6 bits from c3 */
-        cp = (c1 << 12) | (c2 << 6) | c3;
-        return cp;
-    case 4:
-        /* 1st byte must be 11110xxx so we mask with b00011111 = 0x07 */
-        c1 = c[0] & 0x07;
-        /* 2nd byte must be 10xxxxxx so we mask with b00111111 = 0x3f */
-        c2 = c[1] & 0x3f;
-        /* 3rd byte must be 10xxxxxx so we mask with b00111111 = 0x3f */
-        c3 = c[2] & 0x3f;
-        /* 4th byte must be 10xxxxxx so we mask with b00111111 = 0x3f */
-        c4 = c[3] & 0x3f;
-        cp = (c1 << 18) | (c2 << 12) | (c3 << 6) | c4;
-        return cp;
-    default:
-        return 0xfffd; /* replacement character */
-    }
-}
-
 static int is_emoji(uint32_t cp)
 {
     /* http://stackoverflow.com/a/39425959/446149 */

--- a/src/utils/cst_uregex.c
+++ b/src/utils/cst_uregex.c
@@ -40,8 +40,10 @@
 static cst_string *case_conv(const cst_string *in, int to_upper)
 {
     if (in == NULL)
+    {
         return NULL;
-    size_t out_len = 2 * strlen(in);
+    }
+    size_t out_len = 2*strlen(in) + 1;
     unsigned char *output = cst_alloc(unsigned char, out_len);
     if (output == NULL)
     {
@@ -65,7 +67,7 @@ static cst_string *case_conv(const cst_string *in, int to_upper)
     {
         PCRE2_UCHAR8 buffer[120];
         pcre2_get_error_message(result, buffer, 120);
-        fprintf(stderr, "Error case converting: %s\n", buffer);
+        fprintf(stderr, "Error '%s' when case converting (to %s): %s\n", buffer, to_upper ? "upper" : "lower", in);
     }
     delete_cst_uregex(ureg);
     return (cst_string *) output;

--- a/unittests/string_test_main.c
+++ b/unittests/string_test_main.c
@@ -70,11 +70,9 @@ void test_change_case_utf8()
     cst_string in[] = "¡hola MUNDO!";
     cst_string *out;
     out = cst_tolower_utf8(in);
-    printf("\nin: '%s'\tout: '%s'\n", in, out);
     TEST_CHECK(cst_streq(out, "¡hola mundo!"));
     cst_free(out);
     out = cst_toupper_utf8(in);
-    printf("in: '%s'\tout: '%s'\n", in, out);
     TEST_CHECK(cst_streq(out, "¡HOLA MUNDO!"));
     cst_free(out);
     // Test NULL input

--- a/unittests/string_test_main.c
+++ b/unittests/string_test_main.c
@@ -87,9 +87,28 @@ void test_change_case_utf8()
     return;
 }
 
+void test_map_unicode_to_int()
+{
+ map_unicode_to_int* m = cst_unicode_int_map_create();
+ TEST_CHECK(cst_unicode_int_map(m, (const unsigned char*)"a", 0, 0) == m->not_found);
+ TEST_CHECK(cst_unicode_int_map(m, (const unsigned char*)"à", 0, 0) == m->not_found);
+ TEST_CHECK(cst_unicode_int_map(m, (const unsigned char*)"€", 0, 0) == m->not_found);
+ TEST_CHECK(cst_unicode_int_map(m, (const unsigned char*)"🐨", 0, 0) == m->not_found);
+ cst_unicode_int_map(m, (const unsigned char*) "a", 1, 1);
+ cst_unicode_int_map(m, (const unsigned char*) "à", 1, 2);
+ cst_unicode_int_map(m, (const unsigned char*) "€", 1, 3);
+ cst_unicode_int_map(m, (const unsigned char*) "🐨", 1, 4);
+ TEST_CHECK(cst_unicode_int_map(m, (const unsigned char*) "a", 0, 0) == 1);
+ TEST_CHECK(cst_unicode_int_map(m, (const unsigned char*)"à", 0, 0) == 2);
+ TEST_CHECK(cst_unicode_int_map(m, (const unsigned char*)"€", 0, 0) == 3);
+ TEST_CHECK(cst_unicode_int_map(m, (const unsigned char*)"🐨", 0, 0) == 4);
+ cst_unicode_int_map_delete(m);
+}
+
 TEST_LIST =
 {
     {"uregex_match", test_uregex_match},
     {"test_change_case_utf8", test_change_case_utf8},
+    {"test_map_unicode_to_int", test_map_unicode_to_int},
     {0}
 };


### PR DESCRIPTION
This pull request provides UTF-8 support to the Letter To Sound rules (LTS).

These are the most important things to mention:
- This PR breaks backwards compatibility with existing LTS rules (the CMU ones in mimic-english). This was necessary, due to the previous 1 character -> 1 byte assumption. A PR will go to mimic-english to update the rules accordingly.
- The new LTS module does not need to deal with memory alignment issues nor endianness issues.
- Each rule was 6 bytes long and now it is 8 bytes long. With a LTS model made of 30k rules we are moving from 180kb to 240kb, which is smaller than most of the voice models.
- The `lts_apply_val` function was removed because it was unused.
- I fixed an unrelated off-by-one bug in the UTF-8 case conversion routine that was triggered when case converting an empty string `""`.
- I added the `t2p` binary to mimic-core for text2phoneme conversion. There are options added to t2p to disable the lexicon addenda and the lexicon if desired, because eventually I will use this `t2p` binary to validate LTS rules.
- The new format of LTS rules requires new scripts to build them. I will submit pull requests to both pymimic and mimic-english.

This is required for French support. This system might help as well in Spanish support, if we ever have a good alternative to the GPL Saga library.
