### PR TITLE
Fix travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       install:
         - export PATH="`pwd`/build:${PATH}"
         - wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip && unzip -q ninja-linux.zip -d build
-        - pip3 install meson
+        - pip3 install --user meson
       addons: {apt: {packages: [libasound2-dev, python3-pip, pkg-config]}}
     - env: TASK="coverage"
       os: linux
@@ -25,7 +25,7 @@ matrix:
       install:
         - export PATH="`pwd`/build:${PATH}"
         - wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip && unzip -q ninja-linux.zip -d build
-        - pip3 install meson
+        - pip3 install --user meson
       script:
         - meson build --prefix="$PWD/install" -D b_coverage=true
         - ninja -C build test
@@ -38,7 +38,7 @@ matrix:
       install:
         - export PATH="`pwd`/build:${PATH}"
         - wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip && unzip -q ninja-linux.zip -d build
-        - pip3 install meson
+        - pip3 install --user meson
       script:
         - meson build --prefix="$PWD/install" --cross-file="cross/ubuntu-mingw64.txt"
         - ninja -C build install
@@ -49,7 +49,7 @@ matrix:
       install:
         - export PATH="`pwd`/build:${PATH}"
         - wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip && unzip -q ninja-linux.zip -d build
-        - pip3 install meson
+        - pip3 install --user meson
       script:
         - meson build --prefix="$PWD/install" --cross-file="cross/ubuntu-armhf.txt"
         - ninja -C build install


### PR DESCRIPTION
Merging this PR will help the other PR to succeed.


Travis updated the Linux image of their builds and broke the "pip3 install" command. This PR fixes that by using the "--user" flag

https://github.com/travis-ci/travis-ci/issues/8382

If the OSX build passes, let's merge this.