### PR TITLE
Improve cst_val portability. Closes #11

### DIFF
--- a/include/cst_endian.h
+++ b/include/cst_endian.h
@@ -38,29 +38,33 @@
 /*                                                                       */
 /*************************************************************************/
 
-#ifndef CST_ENDIAN_INTERNAL_H
-#define CST_ENDIAN_INTERNAL_H
+#ifndef CST_ENDIAN_H
+#define CST_ENDIAN_H
 
 #include <inttypes.h>
 #include <stdlib.h>
 #include "cst_lib_visibility.h"
-#include "cst_endian.h"
 
-/* EST byte order strings */
-#define BYTE_ORDER_BIG "10"
-#define BYTE_ORDER_LITTLE "01"
+/* This gets set to 1 and we test where the on bit is to determine byteorder */
+MIMIC_CORE_PUBLIC extern const int32_t cst_endian_loc;
+/* Sun, HP, SGI Mips, M68000, PowerPC */
+#define CST_BIG_ENDIAN (((char *)&cst_endian_loc)[0] == 0)
+/* Intel, Alpha, DEC Mips, Vax, ARM, Other MIPS (Casio, Ben Nanonote etc) */
+#define CST_LITTLE_ENDIAN (((char *)&cst_endian_loc)[0] != 0)
+/* Perq (from Three Rivers) has a third byte order -- but we have no support */
 
-#define SWAPINT32(x) ((((uint32_t)x) & 0xff) << 24 | \
-        (((uint32_t)x) & 0xff00) << 8 | \
-	(((uint32_t)x) & 0xff0000) >> 8 | \
-        (((uint32_t)x) & 0xff000000) >> 24)
-#define SWAPINT16(x) ((((uint16_t)x) & 0xff) << 8 | \
-        (((uint16_t)x) & 0xff00) >> 8)
 
-MIMIC_CORE_PRIVATE void swap_bytes_short(int16_t *b, size_t n);
+#ifndef UINTPTR_MAX
+#error "Cannot determine pointer size"
+#endif
 
-MIMIC_CORE_PROTECTED void swapdouble(double *d);
-MIMIC_CORE_PROTECTED void swapfloat(float *f);
+#if (UINTPTR_MAX == UINT32_MAX)
+#define MIMIC_CPU_BITS 32
+#elif (UINTPTR_MAX == UINT64_MAX)
+#define MIMIC_CPU_BITS 64
+#else
+#error "Unknown architecture size"
+#endif
 
 
 #endif /* Header guard */

--- a/include/cst_endian.h
+++ b/include/cst_endian.h
@@ -42,17 +42,6 @@
 #define CST_ENDIAN_H
 
 #include <inttypes.h>
-#include <stdlib.h>
-#include "cst_lib_visibility.h"
-
-/* This gets set to 1 and we test where the on bit is to determine byteorder */
-MIMIC_CORE_PUBLIC extern const int32_t cst_endian_loc;
-/* Sun, HP, SGI Mips, M68000, PowerPC */
-#define CST_BIG_ENDIAN (((char *)&cst_endian_loc)[0] == 0)
-/* Intel, Alpha, DEC Mips, Vax, ARM, Other MIPS (Casio, Ben Nanonote etc) */
-#define CST_LITTLE_ENDIAN (((char *)&cst_endian_loc)[0] != 0)
-/* Perq (from Three Rivers) has a third byte order -- but we have no support */
-
 
 #ifndef UINTPTR_MAX
 #error "Cannot determine pointer size"

--- a/include/cst_endian_internal.h
+++ b/include/cst_endian_internal.h
@@ -46,6 +46,14 @@
 #include "cst_lib_visibility.h"
 #include "cst_endian.h"
 
+/* This gets set to 1 and we test where the on bit is to determine byteorder */
+MIMIC_CORE_PRIVATE extern const int32_t cst_endian_loc;
+/* Sun, HP, SGI Mips, M68000, PowerPC */
+#define CST_BIG_ENDIAN (((char *)&cst_endian_loc)[0] == 0)
+/* Intel, Alpha, DEC Mips, Vax, ARM, Other MIPS (Casio, Ben Nanonote etc) */
+#define CST_LITTLE_ENDIAN (((char *)&cst_endian_loc)[0] != 0)
+/* Perq (from Three Rivers) has a third byte order -- but we have no support */
+
 /* EST byte order strings */
 #define BYTE_ORDER_BIG "10"
 #define BYTE_ORDER_LITTLE "01"

--- a/include/cst_val.h
+++ b/include/cst_val.h
@@ -72,7 +72,7 @@ typedef struct cst_val_cons_struct {
  "order here is important" comments exist.
  */
 typedef struct cst_val_atom_struct {
-#ifdef CST_BIG_ENDIAN
+#if defined(WORDS_BIGENDIAN)
  #if MIMIC_CPU_BITS == 64
     int32_t ref_count;            /* order is here important */
     int32_t type;
@@ -82,7 +82,7 @@ typedef struct cst_val_atom_struct {
  #else
    #error "Unknown CPU bit size"
  #endif
-#else
+#elif defined(WORDS_LITTLEENDIAN)
  #if MIMIC_CPU_BITS == 64
     int32_t type;                   /* order is here important */
     int32_t ref_count;
@@ -92,6 +92,8 @@ typedef struct cst_val_atom_struct {
  #else
   #error "Unknown CPU bit size"
  #endif
+#else
+ #error "Unknown CPU endianness"
 #endif
     union {
 #if MIMIC_CPU_BITS == 64

--- a/include/cst_val_const.h
+++ b/include/cst_val_const.h
@@ -111,6 +111,7 @@
 
 #include "cst_lib_visibility.h"
 #include "cst_val_defs.h"
+#include "cst_endian.h"
 
 /* There is built-in int to string conversions here for numbers   */
 /* up to 20, note if you make this bigger you have to hand change */
@@ -191,62 +192,93 @@ extern const cst_val val_string_24;
 /* problems if you need to use these in any code you are using, you are */
 /* unquestionably doing the wrong thing                                 */
 typedef struct cst_val_atom_struct_float {
-#ifdef WORDS_BIGENDIAN
-    short ref_count;
-    short type;                 /* order is here important */
+#ifdef CST_BIG_ENDIAN
+ #if MIMIC_CPU_BITS == 64
+    int32_t ref_count;            /* order is here important */
+    int32_t type;
+ #elif MIMIC_CPU_BITS == 32
+    int16_t ref_count;
+    int16_t type;                 /* order is here important */
+ #else
+   #error "Unknown bit size"
+ #endif
 #else
-#if (defined(__x86_64__) || defined(_M_X64))
-    int type;                   /* order is here important */
-    int ref_count;
-#else
-    short type;                 /* order is here important */
-    short ref_count;
+ #if MIMIC_CPU_BITS == 64
+    int32_t type;                   /* order is here important */
+    int32_t ref_count;
+ #elif MIMIC_CPU_BITS == 32
+    int16_t type;                 /* order is here important */
+    int16_t ref_count;
+ #else
+  #error "Unknown CPU bit size"
+ #endif
 #endif
-#endif
-#if (defined(__x86_64__) || defined(_M_X64))
+#if MIMIC_CPU_BITS == 64
     double fval;
-#else
+#elif MIMIC_CPU_BITS == 32
     float fval;
+#else
+ #error "Unknown CPU bit size"
 #endif
 } cst_val_float;
 
 typedef struct cst_val_atom_struct_int {
-#ifdef WORDS_BIGENDIAN
-    short ref_count;
-    short type;                 /* order is here important (and unintuitive) */
+#ifdef CST_BIG_ENDIAN
+ #if MIMIC_CPU_BITS == 64
+    int32_t ref_count;            /* order is here important */
+    int32_t type;
+ #elif MIMIC_CPU_BITS == 32
+    int16_t ref_count;
+    int16_t type;                 /* order is here important */
+ #else
+   #error "Unknown CPU bit size"
+ #endif
 #else
-#if (defined(__x86_64__) || defined(_M_X64))
-    int type;                   /* order is here important */
-    int ref_count;
-#else
-    short type;                 /* order is here important */
-    short ref_count;
+ #if MIMIC_CPU_BITS == 64
+    int32_t type;                   /* order is here important */
+    int32_t ref_count;
+ #elif MIMIC_CPU_BITS == 32
+    int16_t type;                 /* order is here important */
+    int16_t ref_count;
+ #else
+  #error "Unknown CPU bit size"
+ #endif
 #endif
-#endif
-#if (defined(__x86_64__) || defined(_M_X64))
-    long long ival;
+#if MIMIC_CPU_BITS == 64
+    int64_t ival;
+#elif MIMIC_CPU_BITS == 32
+    int32_t ival;
 #else
-    int ival;
+ #error "Unknown CPU bit size"
 #endif
 } cst_val_int;
 
 typedef struct cst_val_atom_struct_void {
-#ifdef WORDS_BIGENDIAN
-    short ref_count;
-    short type;                 /* order is here important */
+#ifdef CST_BIG_ENDIAN
+ #if MIMIC_CPU_BITS == 64
+    int32_t ref_count;            /* order is here important */
+    int32_t type;
+ #elif MIMIC_CPU_BITS == 32
+    int16_t ref_count;
+    int16_t type;                 /* order is here important */
+ #else
+   #error "Unknown bit size"
+ #endif
 #else
-#if (defined(__x86_64__) || defined(_M_X64))
-    int type;                   /* order is here important */
-    int ref_count;
-#else
-    short type;                 /* order is here important */
-    short ref_count;
-#endif
+ #if MIMIC_CPU_BITS == 64
+    int32_t type;                   /* order is here important */
+    int32_t ref_count;
+ #elif MIMIC_CPU_BITS == 32
+    int16_t type;                 /* order is here important */
+    int16_t ref_count;
+ #else
+  #error "Unknown bit size"
+ #endif
 #endif
     void *vval;
 } cst_val_void;
 
-#ifdef WORDS_BIGENDIAN
+#ifdef CST_BIG_ENDIAN
 #define DEF_CONST_VAL_INT(N,V) const cst_val_int N={-1, CST_VAL_TYPE_INT, V}
 #define DEF_CONST_VAL_STRING(N,S) const cst_val_void N={-1,CST_VAL_TYPE_STRING,(void *)S}
 #define DEF_CONST_VAL_FLOAT(N,F) const cst_val_float N={-1,CST_VAL_TYPE_FLOAT,(float)F}

--- a/include/cst_val_const.h
+++ b/include/cst_val_const.h
@@ -192,7 +192,7 @@ extern const cst_val val_string_24;
 /* problems if you need to use these in any code you are using, you are */
 /* unquestionably doing the wrong thing                                 */
 typedef struct cst_val_atom_struct_float {
-#ifdef CST_BIG_ENDIAN
+#if defined(WORDS_BIGENDIAN)
  #if MIMIC_CPU_BITS == 64
     int32_t ref_count;            /* order is here important */
     int32_t type;
@@ -202,7 +202,7 @@ typedef struct cst_val_atom_struct_float {
  #else
    #error "Unknown bit size"
  #endif
-#else
+#elif defined(WORDS_LITTLEENDIAN)
  #if MIMIC_CPU_BITS == 64
     int32_t type;                   /* order is here important */
     int32_t ref_count;
@@ -212,6 +212,8 @@ typedef struct cst_val_atom_struct_float {
  #else
   #error "Unknown CPU bit size"
  #endif
+#else /* No endianness defined*/
+ #error "Unknown CPU endianness"
 #endif
 #if MIMIC_CPU_BITS == 64
     double fval;
@@ -223,7 +225,7 @@ typedef struct cst_val_atom_struct_float {
 } cst_val_float;
 
 typedef struct cst_val_atom_struct_int {
-#ifdef CST_BIG_ENDIAN
+#if defined(WORDS_BIGENDIAN)
  #if MIMIC_CPU_BITS == 64
     int32_t ref_count;            /* order is here important */
     int32_t type;
@@ -233,7 +235,7 @@ typedef struct cst_val_atom_struct_int {
  #else
    #error "Unknown CPU bit size"
  #endif
-#else
+#elif defined(WORDS_LITTLEENDIAN)
  #if MIMIC_CPU_BITS == 64
     int32_t type;                   /* order is here important */
     int32_t ref_count;
@@ -243,6 +245,8 @@ typedef struct cst_val_atom_struct_int {
  #else
   #error "Unknown CPU bit size"
  #endif
+#else /* No endianness */
+ #error "Unknown CPU endianness"
 #endif
 #if MIMIC_CPU_BITS == 64
     int64_t ival;
@@ -254,7 +258,7 @@ typedef struct cst_val_atom_struct_int {
 } cst_val_int;
 
 typedef struct cst_val_atom_struct_void {
-#ifdef CST_BIG_ENDIAN
+#if defined(WORDS_BIGENDIAN)
  #if MIMIC_CPU_BITS == 64
     int32_t ref_count;            /* order is here important */
     int32_t type;
@@ -262,9 +266,9 @@ typedef struct cst_val_atom_struct_void {
     int16_t ref_count;
     int16_t type;                 /* order is here important */
  #else
-   #error "Unknown bit size"
+   #error "Unknown CPU bit size"
  #endif
-#else
+#elif defined(WORDS_LITTLEENDIAN)
  #if MIMIC_CPU_BITS == 64
     int32_t type;                   /* order is here important */
     int32_t ref_count;
@@ -272,8 +276,10 @@ typedef struct cst_val_atom_struct_void {
     int16_t type;                 /* order is here important */
     int16_t ref_count;
  #else
-  #error "Unknown bit size"
+  #error "Unknown CPU bit size"
  #endif
+#else
+ #error "Unknown CPU endianness"
 #endif
     void *vval;
 } cst_val_void;

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,14 @@ else
   conf_data.set('MMAP_TYPE', mmap_type_none)
 endif
 
+if host_machine.endian() == 'big'
+  conf_data.set('WORDS_BIGENDIAN', 1)
+elif host_machine.endian() == 'little'
+  conf_data.set('WORDS_LITTLEENDIAN', 1)
+else
+  error('Unknown CPU endianness')
+endif
+
 
 check_headers = [
   ['HAVE_SYS_SOCKET_H', 'sys/socket.h']

--- a/meson.build
+++ b/meson.build
@@ -361,6 +361,7 @@ ttsmimic_public_headers = [
   'include/cst_cg.h',
   'include/cst_clunits.h',
   'include/cst_diphone.h',
+  'include/cst_endian.h',
   'include/cst_error.h',
   'include/cst_features.h',
   'include/cst_ffeatures.h',

--- a/src/utils/cst_error.c
+++ b/src/utils/cst_error.c
@@ -37,11 +37,11 @@
 /*   Error mechanism                                                     */
 /*                                                                       */
 /*************************************************************************/
+#include <setjmp.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include "cst_file.h"
 #include "cst_error.h"
-
 jmp_buf *cst_errjmp = 0;
 
 int cst_errmsg(const char *fmt, ...)

--- a/src/utils/cst_val.c
+++ b/src/utils/cst_val.c
@@ -37,15 +37,19 @@
 /*  Typed values                                                          */
 /*                                                                       */
 /*************************************************************************/
+#include <assert.h>
 #include <math.h>
 #include "cst_file.h"
 #include "cst_val.h"
 #include "cst_string.h"
 #include "cst_tokenstream.h"
+#include <inttypes.h>
 
 static cst_val *new_val()
 {
-    return cst_alloc(struct cst_val_struct, 1);
+    cst_val *res = cst_alloc(struct cst_val_struct, 1);
+    assert(((uintptr_t)res) % 2 == 0);
+    return res;
 }
 
 cst_val *int_val(int i)

--- a/unittests/wave_test_main.c
+++ b/unittests/wave_test_main.c
@@ -19,7 +19,7 @@
 void test_copy(void)
 {
    cst_wave *w1 = new_wave();
-   cst_wave *w2 = new_wave();
+   cst_wave *w2;
    mimic_core_init();
    TEST_CHECK(cst_wave_load_riff(w1, A_WAV1) == 0);
    w2 = copy_wave(w1);


### PR DESCRIPTION
This pull request cleans a bit the assumptions of `cst_val` with issue #11, improving the portability of mimic in 64-bit big endian platforms. It is also safer by failing to compile if the CPU bit size is not detected.

- `WORD_BIGENDIAN` was assuming both big endianness and 32-bit pointer size.
- The implementation assumed int=32bit, short=16 bit, which is usually true
  but not required.
- In little endian, it assumed 32-bit unless
  `defined(__x86_64__) || defined(_M_X64)` was defined. There are more archs.
- The `/* order here is important */` comment did not explain why it
  is important. The reason is because the `type` is set always to an
  odd value and its least significant bit matches the end of the first
  pointer address, so the check for `cons` vs `atom` works as expected.

- Replace int and short with their fixed size equivalents. We aim for a
  fixed known size for the `cst_val` structure, so it makes sense to
  use fixed known size objects in it.
- Define in `cst_endian_internal.h` a variable related to the platform
  size (32 or 64 bit). https://stackoverflow.com/a/5273354/446149
- Split cst_endian_internal in a public and private header, as the endianness
  information is required by cst_val.h and cst_val.h is a public header.
- Drop the arch specific code `__x86_64__`, using the platform size instead.
- Add support for 64-bit big endian architectures here.
- Use an `if/elseif/else` approach in the implementation, keeping the
  `else` for an `#error`, so we make sure we break on unexpected cases.
- Add an assertion in new_val() to ensure that the allocated `cst_val`
  objects have 2-byte alignments.
- Explain the `/* order here is important */`