### PR TITLE
au_pulseaudio.c: include cst_endian_internal.h

### DIFF
--- a/src/audio/au_pulseaudio.c
+++ b/src/audio/au_pulseaudio.c
@@ -46,6 +46,7 @@
 
 #include "cst_string.h"
 #include "cst_wave.h"
+#include "cst_endian_internal.h"
 
 #include <pulse/simple.h>
 


### PR DESCRIPTION
Otherwise, au_pulse.c doesn't build.